### PR TITLE
Fix chargear not working in r6

### DIFF
--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -341,7 +341,7 @@ return function(Vargs, env)
 						local orgHumanoid = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 						local model = service.Players:CreateHumanoidModelFromDescription(
 							orgHumanoid and orgHumanoid:GetAppliedDescription() or service.Players:GetHumanoidDescriptionFromUserId(v.CharacterAppearanceId > 0 and v.CharacterAppearanceId or v.UserId),
-							orgHumanoid and orgHumanoid.RigType or Enum.HumanoidRigType.R15
+							Enum.HumanoidRigType.R15
 						)
 						model.Name = targetName
 


### PR DESCRIPTION
running :chargear as r6 doesn't work because ``BodyHeightScale``, ``BodyDepthScale``, and ``BodyWidthScale`` does not exist.